### PR TITLE
feat: 将默认分类配置由多行文本框改为支持多选的下拉框

### DIFF
--- a/src/main/java/top/puresky/hitokotohub/config/SettingConfig.java
+++ b/src/main/java/top/puresky/hitokotohub/config/SettingConfig.java
@@ -3,6 +3,7 @@ package top.puresky.hitokotohub.config;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
 import reactor.core.publisher.Mono;
+import java.util.List;
 
 public interface SettingConfig {
     Mono<BasicConfig> getBasicConfig();
@@ -15,7 +16,7 @@ public interface SettingConfig {
         @Schema(description = "默认随机条数")
         private Integer randomLimit;
         @Schema(description = "默认分类")
-        private String defaultCategory;
+        private List<String> defaultCategory;
         @Schema(description = "默认返回格式")
         private String encode;
         @Schema(description = "点赞冷却时间（小时）")

--- a/src/main/java/top/puresky/hitokotohub/endpoint/SentencePublicEndpoint.java
+++ b/src/main/java/top/puresky/hitokotohub/endpoint/SentencePublicEndpoint.java
@@ -96,8 +96,7 @@ public class SentencePublicEndpoint implements CustomEndpoint {
             String encode = request.queryParam("encode").filter(StringUtils::isNotBlank)
                 .orElse(config.getEncode());
 
-            // 解析默认分类（多行文本）
-            List<String> defaultCategories = parseCategoryLines(config.getDefaultCategory());
+            List<String> defaultCategories = config.getDefaultCategory();
 
             // 请求参数优先，没有则用设置里的
             List<String> finalCategories = null;
@@ -168,14 +167,6 @@ public class SentencePublicEndpoint implements CustomEndpoint {
         });
     }
 
-    // 解析多行文本为分类 ID 列表
-    private List<String> parseCategoryLines(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return Collections.emptyList();
-        }
-        return Arrays.stream(raw.split("\\n")).map(String::trim)
-            .filter(StringUtils::isNotBlank).toList();
-    }
 
     // 多分类查询
     private ListOptions buildListOptions(List<String> categoryNames) {

--- a/src/main/java/top/puresky/hitokotohub/finder/impl/HitokotoFinderImpl.java
+++ b/src/main/java/top/puresky/hitokotohub/finder/impl/HitokotoFinderImpl.java
@@ -42,7 +42,7 @@ public class HitokotoFinderImpl implements HitokotoFinder {
                     : config.getRandomLimit();
 
                 // 解析请求参数和默认分类
-                List<String> defaultCategories = parseCategoryLines(config.getDefaultCategory());
+                List<String> defaultCategories = config.getDefaultCategory();
 
                 List<String> finalCategories = null;
                 if (StringUtils.isNotBlank(categoryName)) {
@@ -123,14 +123,6 @@ public class HitokotoFinderImpl implements HitokotoFinder {
             .map(this::toCategoryVo);
     }
 
-    // 解析多行文本为分类 ID 列表
-    private List<String> parseCategoryLines(String raw) {
-        if (raw == null || raw.isBlank()) {
-            return Collections.emptyList();
-        }
-        return Arrays.stream(raw.split("\\n")).map(String::trim)
-            .filter(StringUtils::isNotBlank).toList();
-    }
 
     private SentenceVo toSentenceVo(@NonNull Sentence s) {
         var spec = s.getSpec();

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -19,11 +19,19 @@ spec:
           value: 1
           validation: required|number|min:1|max:100
           help: 随机接口默认返回的句子数量
-        - $formkit: textarea
+        - $formkit: select
           name: defaultCategory
           label: 默认分类
-          value: ""
-          help: 每行一个metaDataName（可前往概览页面获取），留空则返回全部分类
+          value: []
+          multiple: true
+          clearable: true
+          autoSelect: false
+          action: /apis/hitokotohub.puresky.top/v1alpha1/categories
+          requestOption:
+            method: GET
+            labelField: spec.name
+            valueField: metadata.name
+          help: 可多选，随机接口默认筛选的分类。留空则返回全部分类。
         - $formkit: select
           name: encode
           label: 默认返回格式

--- a/ui/src/components/Overview.vue
+++ b/ui/src/components/Overview.vue
@@ -176,13 +176,6 @@
                 :stripe="true"
                 table-layout="auto"
         >
-          <el-table-column label="metaDataName">
-            <template #default="{ row }">
-              <span class="cursor-pointer" @click="copyToClipboard(row.categoryName)">
-                {{ row.categoryName }}
-              </span>
-            </template>
-          </el-table-column>
           <el-table-column prop="displayName" label="分类名称"/>
           <el-table-column label="句子总数" min-width="100">
             <template #default="{ row }">


### PR DESCRIPTION
- 将 SettingConfig 中的 defaultCategory 类型由 String 改为 List<String>
- 更新配置文件 settings.yaml，将默认分类配置由多行文本框改为支持多选的下拉框
- 移除 HitokotoFinderImpl 和 SentencePublicEndpoint 中解析多行文本为分类列表的逻辑，直接使用 List<String>
- 删除相关的 parseCategoryLines 方法，简化代码逻辑
- 移除 Overview.vue 中显示单列分类名的表格列，调整表格展示布局