### PR TITLE
feat: 新增句子跳转链接功能，支持自定义链接和关联文章跳转

### DIFF
--- a/src/main/java/top/puresky/hitokotohub/endpoint/SentenceConsoleEndpoint.java
+++ b/src/main/java/top/puresky/hitokotohub/endpoint/SentenceConsoleEndpoint.java
@@ -297,6 +297,12 @@ public class SentenceConsoleEndpoint implements CustomEndpoint {
         // source: trim + 空则填默认值
         String source = StringUtils.trimToNull(spec.getSource());
         spec.setSource(source != null ? source : "未知");
+        // linkUrl: trim + 空则置 null
+        String linkUrl = StringUtils.trimToNull(spec.getLinkUrl());
+        spec.setLinkUrl(linkUrl);
+        // postName: trim + 空则置 null
+        String postName = StringUtils.trimToNull(spec.getPostName());
+        spec.setPostName(postName);
         return sentence;
     }
 

--- a/src/main/java/top/puresky/hitokotohub/endpoint/SentencePublicEndpoint.java
+++ b/src/main/java/top/puresky/hitokotohub/endpoint/SentencePublicEndpoint.java
@@ -24,6 +24,7 @@ import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.content.Post;
 import run.halo.app.core.extension.endpoint.CustomEndpoint;
 import run.halo.app.extension.GroupVersion;
 import run.halo.app.extension.ListOptions;
@@ -150,18 +151,21 @@ public class SentencePublicEndpoint implements CustomEndpoint {
                     .flatMap(text -> ServerResponse.ok().bodyValue(text));
             }
 
-            return sentencesMono.zipWith(displayNameMono).map(tuple -> {
+            return sentencesMono.zipWith(displayNameMono).flatMap(tuple -> {
                 List<Sentence> sentences = tuple.getT1();
                 String displayName = tuple.getT2();
 
-                List<SentenceItem> items = sentences.stream().map(this::toSentenceItem).toList();
-
-                RandomSentenceResponse response = new RandomSentenceResponse();
-                response.setCategoryName(displayName);
-                response.setMaxRandomLimit(config.getMaxRandomLimit());
-                response.setReturned(items.size());
-                response.setSentences(items);
-                return response;
+                return Flux.fromIterable(sentences)
+                    .concatMap(this::toSentenceItem)
+                    .collectList()
+                    .map(items -> {
+                        RandomSentenceResponse response = new RandomSentenceResponse();
+                        response.setCategoryName(displayName);
+                        response.setMaxRandomLimit(config.getMaxRandomLimit());
+                        response.setReturned(items.size());
+                        response.setSentences(items);
+                        return response;
+                    });
             }).flatMap(response -> ServerResponse.ok().bodyValue(response));
         });
     }
@@ -225,7 +229,7 @@ public class SentencePublicEndpoint implements CustomEndpoint {
             long likeCooldown = Duration.ofHours(config.getLikeCooldown()).toMillis();
             if (state != null && state.isCoolingDown(likeCooldown, now)) {
                 long remainingSeconds = state.remainingMillis(likeCooldown, now) / 1000;
-                return client.get(Sentence.class, name).map(
+                return client.get(Sentence.class, name).flatMap(
                         sentence -> buildLikeResponse(sentence, false,
                             "请在 " + TimeFormatUtils.formatRemainingTime(remainingSeconds) + " 后再" + (isUnlike
                                 ? "取消点赞" : "点赞"), "rate_limited"))
@@ -267,7 +271,7 @@ public class SentencePublicEndpoint implements CustomEndpoint {
                                         log.warn("删除点赞记录失败", e);
                                         return Mono.empty();
                                     })
-                                    .thenReturn(buildLikeResponse(updated, true,
+                                    .then(buildLikeResponse(updated, true,
                                         "取消点赞成功", "ok"));
                             }
 
@@ -275,7 +279,7 @@ public class SentencePublicEndpoint implements CustomEndpoint {
                             CategoryViewRecord record = CategoryViewRecordFactory.forLike(
                                 sentence.getSpec().getCategoryName(), name, ip);
                             return client.create(record)
-                                .thenReturn(buildLikeResponse(updated, true,
+                                .then(buildLikeResponse(updated, true,
                                     "点赞成功", "ok"));
                         });
                 })
@@ -284,14 +288,16 @@ public class SentencePublicEndpoint implements CustomEndpoint {
         });
     }
 
-    private @NonNull LikeResponse buildLikeResponse(Sentence sentence, boolean success, String message,
+    private @NonNull Mono<LikeResponse> buildLikeResponse(Sentence sentence, boolean success, String message,
         String code) {
-        LikeResponse response = new LikeResponse();
-        response.setSuccess(success);
-        response.setMessage(message);
-        response.setCode(code);
-        response.setSentence(toSentenceItem(sentence));
-        return response;
+        return toSentenceItem(sentence).map(item -> {
+            LikeResponse response = new LikeResponse();
+            response.setSuccess(success);
+            response.setMessage(message);
+            response.setCode(code);
+            response.setSentence(item);
+            return response;
+        });
     }
 
     private @NonNull LikeResponse buildErrorResponse() {
@@ -303,7 +309,7 @@ public class SentencePublicEndpoint implements CustomEndpoint {
         return response;
     }
 
-    private @NonNull SentenceItem toSentenceItem(@NonNull Sentence s) {
+    private @NonNull Mono<SentenceItem> toSentenceItem(@NonNull Sentence s) {
         SentenceItem item = new SentenceItem();
         item.setMetaName(s.getMetadata().getName());
         item.setAuthor(s.getSpec().getAuthor());
@@ -312,7 +318,29 @@ public class SentencePublicEndpoint implements CustomEndpoint {
         item.setCreatedBy(s.getSpec().getCreatedBy());
         item.setLikeCount(s.getStatus() != null ? s.getStatus().getLikeCount() : 0);
         item.setViewCount(s.getStatus() != null ? s.getStatus().getViewCount() : 0);
-        return item;
+
+        String linkUrl = s.getSpec().getLinkUrl();
+        String postName = s.getSpec().getPostName();
+
+        if (StringUtils.isNotBlank(linkUrl)) {
+            item.setJumpUrl(linkUrl);
+            return Mono.just(item);
+        }
+
+        if (StringUtils.isNotBlank(postName)) {
+            return client.fetch(Post.class, postName)
+                .map(post -> {
+                    String permalink = null;
+                    if (post.getStatus() != null) {
+                        permalink = post.getStatus().getPermalink();
+                    }
+                    item.setJumpUrl(permalink);
+                    return item;
+                })
+                .defaultIfEmpty(item);
+        }
+
+        return Mono.just(item);
     }
 
     // 清理过期的点赞缓存方法
@@ -357,6 +385,8 @@ public class SentencePublicEndpoint implements CustomEndpoint {
         private long likeCount;
         @Schema(description = "浏览数")
         private long viewCount;
+        @Schema(description = "跳转链接")
+        private String jumpUrl;
     }
 
     @Data

--- a/src/main/java/top/puresky/hitokotohub/extension/Sentence.java
+++ b/src/main/java/top/puresky/hitokotohub/extension/Sentence.java
@@ -47,6 +47,14 @@ public class Sentence extends AbstractExtension {
 
         @Schema(description = "创建用户")
         private String createdBy;
+
+        @Size(max = 500)
+        @Schema(description = "自定义跳转链接", maxLength = 500)
+        private String linkUrl;
+
+        @Size(max = 100)
+        @Schema(description = "关联文章名称（metadata.name）", maxLength = 100)
+        private String postName;
     }
 
     @Data

--- a/src/main/java/top/puresky/hitokotohub/finder/HitokotoFinder.java
+++ b/src/main/java/top/puresky/hitokotohub/finder/HitokotoFinder.java
@@ -20,6 +20,7 @@ public interface HitokotoFinder {
         private String categoryName;
         private long likeCount;
         private long viewCount;
+        private String jumpUrl;
     }
 
     @Data

--- a/src/main/java/top/puresky/hitokotohub/finder/impl/HitokotoFinderImpl.java
+++ b/src/main/java/top/puresky/hitokotohub/finder/impl/HitokotoFinderImpl.java
@@ -11,6 +11,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.core.extension.content.Post;
 import run.halo.app.extension.ListOptions;
 import run.halo.app.extension.ListResult;
 import run.halo.app.extension.Metadata;
@@ -118,7 +119,7 @@ public class HitokotoFinderImpl implements HitokotoFinder {
                                 return Flux.fromIterable(randomItems);
                             });
                     })
-                    .map(this::toSentenceVo);
+                    .flatMap(this::toSentenceVo);
             });
     }
 
@@ -141,14 +142,39 @@ public class HitokotoFinderImpl implements HitokotoFinder {
     }
 
 
-    private SentenceVo toSentenceVo(@NonNull Sentence s) {
+    private Mono<SentenceVo> toSentenceVo(@NonNull Sentence s) {
         var spec = s.getSpec();
         var status = s.getStatus();
-        return SentenceVo.builder().name(s.getMetadata().getName()).author(spec.getAuthor())
-            .content(spec.getContent()).source(spec.getSource())
+        var builder = SentenceVo.builder()
+            .name(s.getMetadata().getName())
+            .author(spec.getAuthor())
+            .content(spec.getContent())
+            .source(spec.getSource())
             .categoryName(spec.getCategoryName())
             .likeCount(status != null ? status.getLikeCount() : 0)
-            .viewCount(status != null ? status.getViewCount() : 0).build();
+            .viewCount(status != null ? status.getViewCount() : 0);
+
+        String linkUrl = spec.getLinkUrl();
+        String postName = spec.getPostName();
+
+        if (StringUtils.isNotBlank(linkUrl)) {
+            builder.jumpUrl(linkUrl);
+            return Mono.just(builder.build());
+        }
+
+        if (StringUtils.isNotBlank(postName)) {
+            return client.fetch(Post.class, postName)
+                .map(post -> {
+                    String permalink = null;
+                    if (post.getStatus() != null) {
+                        permalink = post.getStatus().getPermalink();
+                    }
+                    return builder.jumpUrl(permalink).build();
+                })
+                .defaultIfEmpty(builder.build());
+        }
+
+        return Mono.just(builder.build());
     }
 
     private CategoryVo toCategoryVo(@NonNull Category c, long sentenceCount) {

--- a/src/main/resources/templates/hitokoto-scripts.html
+++ b/src/main/resources/templates/hitokoto-scripts.html
@@ -138,7 +138,8 @@
         name: '',
         likes: 0,
         liked: false,
-        busy: false
+        busy: false,
+        jumpUrl: ''
     };
 
     const LIKE_API = '/apis/public.api.hitokotohub.puresky.top/v1alpha1/sentence/like';
@@ -385,30 +386,9 @@
         const container = document.getElementById('quoteContainer');
         state.name = container.getAttribute('data-name') || '';
         state.likes = parseInt(container.getAttribute('data-likes') || '0', 10) || 0;
+        state.jumpUrl = container.getAttribute('data-jump-url') || '';
         state.liked = isLiked(state.name);
         renderLikeUI();
-    }
-
-    /* ==================== 心形粒子动画 ==================== */
-    function createHeartBurst(x, y) {
-        const count = 7;
-        for (let i = 0; i < count; i++) {
-            const heart = document.createElement('div');
-            heart.className = 'heart-particle';
-            heart.textContent = '\u2665';
-            const angle = -Math.PI / 2 + (Math.random() - 0.5) * Math.PI * 1.1;
-            const distance = 55 + Math.random() * 50;
-            const dx = Math.cos(angle) * distance;
-            const dy = Math.sin(angle) * distance;
-            const rot = (Math.random() - 0.5) * 60;
-            heart.style.left = x + 'px';
-            heart.style.top = y + 'px';
-            heart.style.setProperty('--dx', dx + 'px');
-            heart.style.setProperty('--dy', dy + 'px');
-            heart.style.setProperty('--rot', rot + 'deg');
-            document.body.appendChild(heart);
-            setTimeout(() => heart.remove(), 900);
-        }
     }
 
     /* ==================== 轻提示 ==================== */
@@ -453,7 +433,7 @@
                 void btn.offsetWidth;
                 btn.classList.toggle('liked', state.liked);
                 if (state.liked && originX != null && originY != null) {
-                    createHeartBurst(originX, originY);
+                    document.dispatchEvent(new CustomEvent('hitokoto:burst', { detail: { x: originX, y: originY } }));
                 }
             } else {
                 showToast(data.message || '操作过于频繁');
@@ -492,9 +472,12 @@
 
             state.name = s.metaName || s.name || '';
             state.likes = s.likeCount || 0;
+            state.jumpUrl = s.jumpUrl || '';
             state.liked = isLiked(state.name);
             container.setAttribute('data-name', state.name);
             container.setAttribute('data-likes', state.likes);
+            container.setAttribute('data-jump-url', state.jumpUrl);
+            container.classList.toggle('quote-container--clickable', !!state.jumpUrl);
             renderLikeUI();
 
             textEl.style.opacity = '1';
@@ -833,6 +816,24 @@
         }
     });
 
+    /* ==================== 句子点击跳转（仅句子文字区域可点击，区分单击/双击） ==================== */
+    let clickTimer = null;
+    const quoteTextEl = document.getElementById('quoteText');
+    quoteTextEl.addEventListener('click', (e) => {
+        if (clickTimer) {
+            /* 第二次点击（双击），取消跳转，交给 document 的 dblclick 处理点赞 */
+            clearTimeout(clickTimer);
+            clickTimer = null;
+            return;
+        }
+        clickTimer = setTimeout(() => {
+            clickTimer = null;
+            if (state.jumpUrl) {
+                window.open(state.jumpUrl, '_blank', 'noopener');
+            }
+        }, 250);
+    });
+
     /* ==================== 樱花动画 ==================== */
     /* 读取服务端配置决定是否启用花瓣动画 */
     (function() {
@@ -843,8 +844,8 @@
 
         var sakuraList = [];
         var sakuraContainer = document.getElementById('sakura-container');
-        var isMobile = window.innerWidth < 640;
-        var SAKURA_MAX = isMobile ? 35 : 75;
+        var isMobile = window.innerWidth < 768 || ('ontouchstart' in window && window.innerWidth < 1024);
+        var SAKURA_MAX = isMobile ? 15 : 75;
         var mouseX = -1000, mouseY = -1000;
         var mouseActive = false;    /* 鼠标是否在页面内 */
         var mouseDown = false;      /* 鼠标是否按住 */
@@ -931,8 +932,8 @@
                 blur = 0;
             }
 
-            /* 移动端减速 35%，飘落更从容 */
-            if (isMobile) baseSpeed *= 0.65;
+            /* 移动端减速 60%，飘落更舒缓 */
+            if (isMobile) baseSpeed *= 0.4;
 
             petal.style.width = size + 'px';
             petal.style.height = size + 'px';
@@ -1110,9 +1111,12 @@
         }
 
         /* 点击绽放可配置参数 */
-        var BURST_COUNT = 10;       /* 基础花瓣数（实际 ±3 随机） */
-        var BURST_DIST_MIN = 50;   /* 最小扩散半径 (px) */
-        var BURST_DIST_MAX = 130;  /* 最大扩散半径 (px) */
+        var BURST_COUNT = isMobile ? 5 : 10;      /* 基础花瓣数：移动端5，PC端10 */
+        var BURST_VARIANCE = isMobile ? 3 : 7;    /* 随机浮动：移动端±3，PC端±7 */
+        var BURST_DIST_MIN = isMobile ? 35 : 50;  /* 最小扩散半径 */
+        var BURST_DIST_MAX = isMobile ? 90 : 130; /* 最大扩散半径 */
+        var BURST_SPEED_MIN = isMobile ? 1.8 : 2.5;
+        var BURST_SPEED_MAX = isMobile ? 3.5 : 5.0;
 
         /**
          * 鼠标点击绽放特效（纯 JS 驱动，无缝融入飘落系统）：
@@ -1120,7 +1124,7 @@
          *   全程由 animateSakura 物理引擎统一驱动，零切换、零间隙。
          */
         function createBurst(x, y) {
-            var count = BURST_COUNT + Math.floor(Math.random() * 7);  /* 10-16 */
+            var count = BURST_COUNT + Math.floor(Math.random() * BURST_VARIANCE);
             for (var i = 0; i < count; i++) {
                 (function() {
                     var sakura = document.createElement('div');
@@ -1130,8 +1134,10 @@
 
                     var angle = (Math.PI * 2 * i) / count + (Math.random() - 0.5) * 0.6;
                     var br = (Math.random() - 0.5) * 360;
-                    var size = Math.random() * 6 + 6;
-                    var burstSpeed = 2.5 + Math.random() * 2.5;  /* 2.5-5.0 px/帧 高速扩散 */
+                    var size = isMobile
+                        ? Math.random() * 4 + 5
+                        : Math.random() * 6 + 6;
+                    var burstSpeed = BURST_SPEED_MIN + Math.random() * (BURST_SPEED_MAX - BURST_SPEED_MIN);
 
                     petal.style.width = size + 'px';
                     petal.style.height = size + 'px';
@@ -1192,11 +1198,16 @@
             createBurst(e.clientX, e.clientY);
         });
 
+        /* 点赞成功时触发樱花绽放 */
+        document.addEventListener('hitokoto:burst', function(e) {
+            createBurst(e.detail.x, e.detail.y);
+        });
+
         /* 播种与密度管理 */
-        var seedCount = isMobile ? 18 : 35;
-        var spawnInterval = isMobile ? 1200 : 600;
+        var seedCount = isMobile ? 8 : 35;
+        var spawnInterval = isMobile ? 2000 : 600;
         for (var i = 0; i < seedCount; i++) {
-            setTimeout(createSakura, i * (isMobile ? 200 : 100));
+            setTimeout(createSakura, i * (isMobile ? 350 : 100));
         }
         setInterval(function() {
             /* 根据当前数量动态调整创建速率 */

--- a/src/main/resources/templates/hitokoto-styles.html
+++ b/src/main/resources/templates/hitokoto-styles.html
@@ -133,18 +133,6 @@
             100% { transform: scale(1); }
         }
 
-        @keyframes heartBurst {
-            0% {
-                transform: translate(-50%, -50%) scale(0) rotate(0deg);
-                opacity: 1;
-            }
-            60% { opacity: 1; }
-            100% {
-                transform: translate(calc(-50% + var(--dx)), calc(-50% + var(--dy))) scale(1.1) rotate(var(--rot));
-                opacity: 0;
-            }
-        }
-
         @keyframes toastIn {
             from {
                 opacity: 0;
@@ -311,9 +299,10 @@
             color: var(--text);
             overflow-wrap: break-word;
             word-break: break-word;
-            transition: opacity 0.3s ease, color 0.4s ease;
-            cursor: pointer;
+            transition: opacity 0.3s ease, color 0.4s ease, text-shadow 0.3s ease;
+            cursor: default;
             text-shadow: var(--shadow-text);
+            display: inline;
         }
 
         /* 流光渐变：逐字动画完成后渐显 */
@@ -375,6 +364,17 @@
             height: 1px;
             background: linear-gradient(90deg, transparent, var(--line), transparent);
             opacity: 0;
+        }
+
+        /* 可点击句子（带跳转链接）—— 仅鼠标悬停在句子文字上时才触发 */
+        .quote-container--clickable .quote-text {
+            cursor: pointer;
+            transition: color 0.3s ease, text-shadow 0.3s ease;
+        }
+
+        .quote-container--clickable .quote-text:hover {
+            color: var(--accent);
+            text-shadow: 0 0 24px var(--accent-glow);
         }
 
         /* 右上角点赞按钮 */
@@ -531,17 +531,6 @@
 
         .next-btn:hover .line::after {
             transform: translateY(0);
-        }
-
-        /* 双击点赞飞出的心形粒子 */
-        .heart-particle {
-            position: fixed;
-            z-index: 100;
-            pointer-events: none;
-            color: var(--accent);
-            font-size: 14px;
-            animation: heartBurst 0.9s ease-out forwards;
-            text-shadow: 0 0 8px var(--accent-glow);
         }
 
         /* 轻提示 */
@@ -732,10 +721,6 @@
 
             .next-btn .line {
                 height: 2rem;
-            }
-
-            .heart-particle {
-                font-size: 16px;
             }
         }
 

--- a/src/main/resources/templates/hitokoto.html
+++ b/src/main/resources/templates/hitokoto.html
@@ -83,7 +83,8 @@
 <main>
     <div class="quote-container" id="quoteContainer"
          th:each="s : ${hitokotoFinder.randomSentences(1, null)}"
-         th:attr="data-name=${s.name}, data-likes=${s.likeCount}"
+         th:attr="data-name=${s.name}, data-likes=${s.likeCount}, data-jump-url=${s.jumpUrl}"
+         th:classappend="${s.jumpUrl} ? 'quote-container--clickable'"
          aria-live="polite" aria-atomic="true"
          aria-label="当前句子">
         <h1 class="quote-text" id="quoteText" th:text="${s.content}">加载中...</h1>

--- a/ui/src/api/generated/models/sentence-item.ts
+++ b/ui/src/api/generated/models/sentence-item.ts
@@ -62,5 +62,11 @@ export interface SentenceItem {
      * @memberof SentenceItem
      */
     'viewCount'?: number;
+    /**
+     * 跳转链接
+     * @type {string}
+     * @memberof SentenceItem
+     */
+    'jumpUrl'?: string;
 }
 

--- a/ui/src/api/generated/models/sentence-spec.ts
+++ b/ui/src/api/generated/models/sentence-spec.ts
@@ -50,5 +50,17 @@ export interface SentenceSpec {
      * @memberof SentenceSpec
      */
     'source'?: string;
+    /**
+     * 自定义跳转链接
+     * @type {string}
+     * @memberof SentenceSpec
+     */
+    'linkUrl'?: string;
+    /**
+     * 关联文章名称（metadata.name）
+     * @type {string}
+     * @memberof SentenceSpec
+     */
+    'postName'?: string;
 }
 

--- a/ui/src/components/SentenceList.vue
+++ b/ui/src/components/SentenceList.vue
@@ -403,6 +403,51 @@
         >
           已发布
         </FormKit>
+
+        <FormKit
+          v-model="formData.linkType"
+          type="select"
+          label="跳转方式"
+          placeholder="请选择跳转方式"
+          help="设置后，前台展示该句子时点击可跳转到对应地址"
+          :options="[
+            { label: '不跳转', value: 'none' },
+            { label: '自定义链接', value: 'url' },
+            { label: '关联文章', value: 'post' },
+          ]"
+        />
+        <FormKit
+          v-if="formData.linkType === 'url'"
+          v-model="formData.linkUrl"
+          type="text"
+          label="链接地址"
+          placeholder="请输入完整 URL，如 https://example.com/article"
+        />
+        <div v-if="formData.linkType === 'post'" class="form-field-wrapper">
+          <label class="form-field-label">关联文章</label>
+          <el-select
+            v-model="formData.postName"
+            filterable
+            clearable
+            placeholder="选择文章（按发布时间倒序，支持搜索）"
+            :loading="postSearchLoading"
+            @visible-change="handlePostDropdownVisible"
+            class="w-full post-select"
+            size="default"
+          >
+            <el-option
+              v-for="post in postOptions"
+              :key="post.name"
+              :label="post.title"
+              :value="post.name"
+            />
+            <template #empty>
+              <div class="text-center text-xs text-gray-400 py-2">
+                {{ postSearchLoading ? '加载中...' : (postsLoaded ? '未找到匹配的文章' : '点击下拉加载文章列表') }}
+              </div>
+            </template>
+          </el-select>
+        </div>
       </div>
       <template #footer>
         <div class="modal-footer">
@@ -713,6 +758,7 @@ import {
   VStatusDot,
   VTag,
 } from '@halo-dev/components'
+import {axiosInstance} from '@halo-dev/api-client'
 import {utils} from '@halo-dev/ui-shared'
 import {Delete, EditPen, View} from '@element-plus/icons-vue'
 import {computed, onMounted, onUnmounted, ref, watch} from 'vue'
@@ -780,6 +826,83 @@ const formData = ref({
   author: '匿名',
   source: '未知',
   published: true,
+  linkType: 'none' as 'none' | 'url' | 'post',
+  linkUrl: '',
+  postName: '',
+})
+
+// 文章搜索相关状态
+const allPosts = ref<{ name: string; title: string }[]>([])
+const postOptions = ref<{ name: string; title: string }[]>([])
+const postSearchLoading = ref(false)
+const postsLoaded = ref(false)
+
+/**
+ * 分页拉取全部已发布文章（Content API），缓存到 allPosts
+ * Content API /apis/content.halo.run/v1alpha1/posts 不支持 keyword 搜索，
+ * 所以一次性加载全部文章到前端，由 el-select filterable 本地过滤。
+ */
+const fetchAllPosts = async () => {
+  if (postsLoaded.value) {
+    postOptions.value = allPosts.value
+    return
+  }
+  postSearchLoading.value = true
+  try {
+    const result: { name: string; title: string }[] = []
+    const pageSize = 100
+    let page = 1
+    let hasNext = true
+    while (hasNext) {
+      const { data } = await axiosInstance.get('/apis/content.halo.run/v1alpha1/posts', {
+        params: {
+          page,
+          size: pageSize,
+          sort: 'spec.publishTime,desc',
+        },
+      })
+      const items = data.items || []
+      for (const p of items) {
+        if (p.spec && p.status?.permalink) {
+          result.push({
+            name: p.metadata.name,
+            title: p.spec.title || '(无标题)',
+          })
+        }
+      }
+      hasNext = data.hasNext === true && items.length === pageSize
+      page++
+      /* 安全上限：最多拉取 20 页（2000 篇），防止极端情况死循环 */
+      if (page > 20) break
+    }
+    allPosts.value = result
+    postOptions.value = result
+    postsLoaded.value = true
+  } catch (e) {
+    console.error('加载文章列表失败', e)
+    toast.error('加载文章列表失败')
+  } finally {
+    postSearchLoading.value = false
+  }
+}
+
+const handlePostDropdownVisible = (visible: boolean) => {
+  if (visible && !postsLoaded.value) {
+    fetchAllPosts()
+  }
+}
+
+// 监听linkType变化，清空不相关字段，切换到"关联文章"时预加载文章列表
+watch(() => formData.value.linkType, (newType) => {
+  if (newType !== 'url') {
+    formData.value.linkUrl = ''
+  }
+  if (newType !== 'post') {
+    formData.value.postName = ''
+  } else {
+    // 切换到"关联文章"时自动加载文章列表
+    fetchAllPosts()
+  }
 })
 
 const showBatchImportModal = ref(false)
@@ -1122,6 +1245,15 @@ const handleCreate = () => {
     author: '匿名',
     source: '未知',
     published: true,
+    linkType: 'none',
+    linkUrl: '',
+    postName: '',
+  }
+  // 新建时如果已有缓存，直接使用；切换到"关联文章"时watch会自动填充
+  if (postsLoaded.value) {
+    postOptions.value = allPosts.value
+  } else {
+    postOptions.value = []
   }
   showFormModal.value = true
 }
@@ -1276,11 +1408,20 @@ const buildSentence = (
         categoryName: string,
         author?: string,
         source?: string,
+        linkUrl?: string,
+        postName?: string,
 ): Sentence => ({
   apiVersion: 'hitokotohub.puresky.top/v1alpha1',
   kind: 'Sentence',
   metadata: {generateName: 'sentence-', name: ''},
-  spec: {content, categoryName, author: author || '匿名', source: source || '未知'},
+  spec: {
+    content,
+    categoryName,
+    author: author || '匿名',
+    source: source || '未知',
+    linkUrl: linkUrl || undefined,
+    postName: postName || undefined,
+  } as any,
 })
 
 const batchCreate = async (sentenceList: Sentence[]): Promise<BatchCreateSentenceResult> => {
@@ -1323,8 +1464,25 @@ const handleSave = async () => {
     toast.warning('请填写句子内容和分类')
     return
   }
+  if (formData.value.linkType === 'url') {
+    const url = formData.value.linkUrl.trim()
+    if (!url) {
+      toast.warning('请输入跳转链接URL')
+      return
+    }
+    if (!/^https?:\/\/.+/.test(url)) {
+      toast.warning('请输入以 http:// 或 https:// 开头的有效URL')
+      return
+    }
+  }
+  if (formData.value.linkType === 'post' && !formData.value.postName) {
+    toast.warning('请选择关联文章')
+    return
+  }
   saving.value = true
   try {
+    const linkUrl = formData.value.linkType === 'url' ? formData.value.linkUrl.trim() : undefined
+    const postName = formData.value.linkType === 'post' ? formData.value.postName : undefined
     if (isEditing.value && editingOriginalSentence.value) {
       // 重新获取最新数据，防止多次修改导致版本冲突
       const { data: latestSentence } = await sentenceCoreApiClient.sentence.getSentence({
@@ -1338,7 +1496,9 @@ const handleSave = async () => {
           categoryName: formData.value.categoryName,
           author: formData.value.author,
           source: formData.value.source,
-        },
+          linkUrl,
+          postName,
+        } as any,
         status: {...latestSentence.status, published: formData.value.published},
       }
       await sentenceCoreApiClient.sentence.updateSentence({
@@ -1352,6 +1512,8 @@ const handleSave = async () => {
               formData.value.categoryName,
               formData.value.author,
               formData.value.source,
+              linkUrl,
+              postName,
       )
       await batchCreate([sentence])
       toast.success('创建成功')
@@ -1412,12 +1574,55 @@ const handleEdit = (sentence: Sentence) => {
   isEditing.value = true
   editingSentenceName.value = sentence.metadata.name
   editingOriginalSentence.value = sentence
+  const spec = sentence.spec as any
+  let linkType: 'none' | 'url' | 'post' = 'none'
+  let linkUrl = ''
+  let postName = ''
+  postOptions.value = []
+  if (spec.linkUrl) {
+    linkType = 'url'
+    linkUrl = spec.linkUrl
+  } else if (spec.postName) {
+    linkType = 'post'
+    postName = spec.postName
+    // 如果已加载全部文章，直接从中查找；否则异步获取单篇标题作为占位
+    if (postsLoaded.value) {
+      postOptions.value = allPosts.value
+      const found = allPosts.value.find(p => p.name === postName)
+      if (!found) {
+        // 文章不在列表中（可能是已删除/未发布），仍然显示
+        axiosInstance.get(`/apis/content.halo.run/v1alpha1/posts/${postName}`)
+          .then(({ data }) => {
+            const title = data.spec?.title || '(无标题)'
+            postOptions.value = [...allPosts.value, { name: postName, title }]
+          })
+          .catch(() => {
+            postOptions.value = [...allPosts.value, { name: postName, title: '(文章不存在)' }]
+          })
+      }
+    } else {
+      axiosInstance.get(`/apis/content.halo.run/v1alpha1/posts/${postName}`)
+        .then(({ data }) => {
+          const title = data.spec?.title || '(无标题)'
+          postOptions.value = [{ name: postName, title }]
+        })
+        .catch(() => {
+          postOptions.value = [{ name: postName, title: '(文章不存在)' }]
+        })
+    }
+  } else if (postsLoaded.value) {
+    // 无关联文章，但已加载全部列表，直接填充
+    postOptions.value = allPosts.value
+  }
   formData.value = {
     content: sentence.spec.content,
     categoryName: sentence.spec.categoryName,
     author: sentence.spec.author || '匿名',
     source: sentence.spec.source || '未知',
     published: sentence.status?.published ?? true,
+    linkType,
+    linkUrl,
+    postName,
   }
   showFormModal.value = true
 }
@@ -1850,5 +2055,17 @@ onUnmounted(() => {
   color: #111827;
   border-color: #d1d5db;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
+}
+
+.form-field-wrapper {
+  margin-bottom: 16px;
+}
+
+.form-field-label {
+  display: block;
+  font-size: 13px;
+  font-weight: 500;
+  color: #111827;
+  margin-bottom: 6px;
 }
 </style>


### PR DESCRIPTION
1.  新增SentenceSpec的linkUrl和postName字段，支持配置自定义跳转链接或关联文章
2.  后端实现根据关联文章名称自动获取永久链接
3.  前端新增句子编辑弹窗的跳转配置选项，支持选择跳转方式
4.  前台句子支持点击跳转，区分单击跳转和双击点赞行为
5.  优化前端样式和樱花动画适配移动端
6.  移除旧的点赞心形粒子动画，改用樱花点击特效