### PR TITLE
功能（模板）：添加可自定义的左上角标志文本及可点击链接

### DIFF
--- a/src/main/java/top/puresky/hitokotohub/HitokotoTemplateRouter.java
+++ b/src/main/java/top/puresky/hitokotohub/HitokotoTemplateRouter.java
@@ -57,6 +57,11 @@ public class HitokotoTemplateRouter {
                 model.put("templateShowHint", templateConfig.getTemplateShowHint());
                 model.put("enableAutoRefresh", templateConfig.getEnableAutoRefresh());
                 model.put("autoRefreshInterval", templateConfig.getAutoRefreshInterval());
+                // 左上角文字：留空回退为默认文字；链接开关未设置时默认关闭（保持原行为）
+                model.put("templateLogoText", StringUtils.defaultIfBlank(
+                    templateConfig.getTemplateLogoText(), "LiteWords"));
+                model.put("templateLogoLinkEnabled",
+                    Boolean.TRUE.equals(templateConfig.getTemplateLogoLinkEnabled()));
                 // 分享链接直达视图：禁用自动切换句子，避免打断被分享句子的展示
                 model.put("shareView", shareView);
                 return templateNameResolver.resolveTemplateNameOrDefault(request.exchange(),

--- a/src/main/java/top/puresky/hitokotohub/config/SettingConfig.java
+++ b/src/main/java/top/puresky/hitokotohub/config/SettingConfig.java
@@ -100,6 +100,10 @@ public interface SettingConfig {
     @Data
     class TemplateConfig {
         public static final String GROUP = "template";
+        @Schema(description = "模板左上角展示的文字，留空则使用默认文字 LiteWords")
+        private String templateLogoText;
+        @Schema(description = "是否开启点击左上角文字回到站点首页")
+        private Boolean templateLogoLinkEnabled;
         @Schema(description = "模板默认主题：auto 跟随系统, dark 暗色, light 亮色")
         private String templateTheme;
         @Schema(description = "是否显示花瓣飘落动画")

--- a/src/main/resources/extensions/settings.yaml
+++ b/src/main/resources/extensions/settings.yaml
@@ -369,6 +369,17 @@ spec:
     - group: template
       label: 模板展示设置
       formSchema:
+        - $formkit: text
+          name: templateLogoText
+          label: 左上角文字
+          value: LiteWords
+          placeholder: 请输入左上角展示的文字
+          help: 模板页面左上角展示的文字，留空则使用默认文字 LiteWords
+        - $formkit: switch
+          name: templateLogoLinkEnabled
+          label: 点击回到站点首页
+          value: false
+          help: 开启后，点击模板页面左上角的文字将跳转回主站首页；关闭则仅作展示，不可点击
         - $formkit: select
           name: templateTheme
           label: 默认主题

--- a/src/main/resources/templates/hitokoto-styles.html
+++ b/src/main/resources/templates/hitokoto-styles.html
@@ -267,6 +267,7 @@
             text-transform: uppercase;
             color: var(--muted);
             cursor: pointer;
+            text-decoration: none;
             transition: color 0.3s;
             font-family: var(--ui-font);
             opacity: 0;

--- a/src/main/resources/templates/hitokoto.html
+++ b/src/main/resources/templates/hitokoto.html
@@ -42,7 +42,11 @@
 <div class="noise-overlay"></div>
 
 <header>
-    <div class="music-btn">LiteWords</div>
+    <!-- 左上角文字：开启"点击回到站点首页"时渲染为链接，否则仅作展示 -->
+    <a class="music-btn" th:if="${templateLogoLinkEnabled}" th:href="@{/}"
+       th:text="${templateLogoText}" aria-label="回到站点首页">LiteWords</a>
+    <div class="music-btn" th:unless="${templateLogoLinkEnabled}"
+         th:text="${templateLogoText}">LiteWords</div>
     <div class="header-actions">
         <button class="theme-toggle" id="themeToggle" type="button" aria-label="切换主题" data-tooltip="切换主题">
             <!-- 太阳图标：暗色模式下显示，点击切换到亮色 -->


### PR DESCRIPTION
1. 为标志文本和主页链接开关新增模板设置项
2. 新增模板数据模型属性，用于前端渲染
3. 更新 HTML 模板，按条件渲染链接或静态文本
4. 修复音乐按钮元素缺失的 `text-decoration: none` 样式问题 #35